### PR TITLE
Allow options to be passed to mpv when initializing playlists.

### DIFF
--- a/mpvc
+++ b/mpvc
@@ -808,7 +808,7 @@ main() {
     for ((pos=1; pos <= $#; pos++)); do
         test "${@:$pos:1}" = "--" && {
             MPVOPTIONS="$MPVOPTIONS ${@:$pos+1}"
-            set -- "${@:1:$pos-1}"
+            set -- "${@:0:$pos}"
         }
     done
 

--- a/mpvc
+++ b/mpvc
@@ -755,21 +755,21 @@ EOF
 }
 
 validateDeps() {
-    type mpv >/dev/null  2>&1 || {
+    type mpv 2>&1 > /dev/null || {
         printf '%s\n' "mpv is not installed on your \$PATH." >&2
         exit 4
     }
 
-    type socat >/dev/null 2>&1 && SOCKETCOMMAND="socat - $SOCKET"
-    type nc >/dev/null 2>&1 && SOCKETCOMMAND="nc -U -N $SOCKET"
+    type socat 2>&1 > /dev/null && SOCKETCOMMAND="socat - $SOCKET"
+    type nc 2>&1 > /dev/null && SOCKETCOMMAND="nc -U -N $SOCKET"
 
     test "$SOCKETCOMMAND" || {
         printf '%s\n' "Cannot find socat or nc on your \$PATH." >&2
         exit 4
     }
 
-    type seq >/dev/null 2>&1 && SEQCOMMAND="seq"
-    type jot >/dev/null 2>&1 && SEQCOMMAND="jot"
+    type seq 2>&1 > /dev/null && SEQCOMMAND="seq"
+    type jot 2>&1 > /dev/null && SEQCOMMAND="jot"
 
     test "$SEQCOMMAND" || {
         printf '%s\n' "Cannot find seq or jot on your \$PATH." >&2

--- a/mpvc
+++ b/mpvc
@@ -755,21 +755,21 @@ EOF
 }
 
 validateDeps() {
-    type mpv 2>&1 > /dev/null || {
+    type mpv >/dev/null  2>&1 || {
         printf '%s\n' "mpv is not installed on your \$PATH." >&2
         exit 4
     }
 
-    type socat 2>&1 > /dev/null && SOCKETCOMMAND="socat - $SOCKET"
-    type nc 2>&1 > /dev/null && SOCKETCOMMAND="nc -U -N $SOCKET"
+    type socat >/dev/null 2>&1 && SOCKETCOMMAND="socat - $SOCKET"
+    type nc >/dev/null 2>&1 && SOCKETCOMMAND="nc -U -N $SOCKET"
 
     test "$SOCKETCOMMAND" || {
         printf '%s\n' "Cannot find socat or nc on your \$PATH." >&2
         exit 4
     }
 
-    type seq 2>&1 > /dev/null && SEQCOMMAND="seq"
-    type jot 2>&1 > /dev/null && SEQCOMMAND="jot"
+    type seq >/dev/null 2>&1 && SEQCOMMAND="seq"
+    type jot >/dev/null 2>&1 && SEQCOMMAND="jot"
 
     test "$SEQCOMMAND" || {
         printf '%s\n' "Cannot find seq or jot on your \$PATH." >&2

--- a/mpvc
+++ b/mpvc
@@ -5,6 +5,7 @@
 # https://mpv.io/manual/master/#json-ipc
 
 SOCKET=${SOCKET:-/tmp/mpvsocket}
+MPVOPTIONS="--no-audio-display"
 
 usage() {
     cat >&2 << EOF
@@ -32,6 +33,7 @@ Usage: $(basename $0) [-S "socket"] [-a "filenames"] [-f "format string"]
     -S | --socket   : Set socket location [default: $SOCKET].
     -q | --quiet    : Surpress all text output.
     -Q | --vid=no   : Start mpv with video output disabled.
+    -- |            : When adding files all options after -- are passed to mpv.
     -h | --help     : Print this help.
 
 Formatting:
@@ -240,8 +242,8 @@ appendTrack() {
         printf '%s\n' "{ \"command\": [\"loadfile\", \"$filename\", \
 \"append-play\" ] }" | $SOCKETCOMMAND 2>&1 > /dev/null
     } || {
-        exec mpv --really-quiet --no-audio-display --idle=once \
-            --input-unix-socket=${SOCKET} $VID "$filename" &
+        exec mpv --really-quiet --idle=once --input-unix-socket=${SOCKET} \
+            $MPVOPTIONS "$filename" &
 
         # wait up to 5 seconds for mpv to start on $SOCKET
         for i in $($SEQCOMMAND 50); do
@@ -802,7 +804,15 @@ getVersion() {
 main() {
     validateDeps
 
-    # grab input files first
+    # grab mpv options first if any
+    for ((pos=1; pos <= $#; pos++)); do
+        test "${@:$pos:1}" = "--" && {
+            MPVOPTIONS="$MPVOPTIONS ${@:$pos+1}"
+            set -- "${@:1:$pos-1}"
+        }
+    done
+
+    # grab input files next
     for arg in "$@"; do
         case "$arg" in
             -?|--*) APPENDFLAG=false ;;
@@ -974,7 +984,7 @@ for arg in "$@"; do
         -q|--quiet)       QUIETFLAG=true  ;;
         -S|--socket)      SOCKETFLAG=true ;;
         -f|--format)      FORMATFLAG=true ;;
-        -Q|--vid=no)      VID="--vid=no"  ;;
+        -Q|--vid=no)      MPVOPTIONS="$MPVOPTIONS --vid=no" ;;
         -K|--killall)     killAllMpv      ;;
         --list-options)   usage 0         ;;
         -h|--help|h|help) usage 0         ;;


### PR DESCRIPTION
All options after `--` are passed to mpv when it is first opened.