### PR TITLE
Better regex for finding existing mpv instance

### DIFF
--- a/mpvc
+++ b/mpvc
@@ -251,7 +251,7 @@ appendTrack() {
 
     ps ax -ww | grep -v grep | grep -wq "mpv.*$SOCKET" && {
         printf '%s\n' "{ \"command\": [\"loadfile\", \"$filename\", \
-\"append-play\" ] }" | $SOCKETCOMMAND /dev/null 2>&1
+\"append-play\" ] }" | $SOCKETCOMMAND 2>&1 > /dev/null
     } || {
         exec mpv --really-quiet --idle=once --input-ipc-server="${SOCKET}" \
             $MPVOPTIONS "$filename" &

--- a/mpvc
+++ b/mpvc
@@ -239,7 +239,7 @@ appendTrack() {
     filename="$@"
 
     ps ax -ww | grep -v grep | \
-    grep -wq "\bmpv\b.*--input-\(unix\|ipc\).*$SOCKET" && {
+    grep -wq "mpv[[:space:]].*--input-\(unix\|ipc\).*$SOCKET" && {
         printf '%s\n' "{ \"command\": [\"loadfile\", \"$filename\", \
 \"append-play\" ] }" | $SOCKETCOMMAND 2>&1 > /dev/null
     } || {

--- a/mpvc
+++ b/mpvc
@@ -211,9 +211,11 @@ getPlaylist() {
 
     calculateTerminalHeight
 
-    test "${SEQCOMMAND}" = "jot" && REPS=$((LAST - FIRST + 1))
+    test "${SEQCOMMAND}" = "jot" && \
+        NUMBERS=$("$SEQCOMMAND" $((LAST - FIRST + 1)) "$FIRST" "$LAST") || \
+        NUMBERS=$("$SEQCOMMAND" "$FIRST" "$LAST")
 
-    for i in $("$SEQCOMMAND" "$REPS" "$FIRST" "$LAST"); do
+    for i in $NUMBERS; do
         filename=$(printf '%s\n' "{ \"command\": [\"get_property_string\", \
 \"playlist/$((i - 1))/filename\"] }" | $SOCKETCOMMAND 2> /dev/null | \
             cut -d\" -f 4)

--- a/mpvc
+++ b/mpvc
@@ -238,7 +238,8 @@ getPlaylist() {
 appendTrack() {
     filename="$@"
 
-    ps ax -ww | grep -v grep | grep -wq "mpv.*$SOCKET" && {
+    ps ax -ww | grep -v grep | \
+    grep -wq "\bmpv\b.*--input-\(unix\|ipc\).*$SOCKET" && {
         printf '%s\n' "{ \"command\": [\"loadfile\", \"$filename\", \
 \"append-play\" ] }" | $SOCKETCOMMAND 2>&1 > /dev/null
     } || {


### PR DESCRIPTION
To prevent `mpvc` itself from being a match.
