### PR TITLE
Remove error with invalid `nc -N` option

### DIFF
--- a/mpvc
+++ b/mpvc
@@ -761,7 +761,7 @@ validateDeps() {
     }
 
     type socat >/dev/null 2>&1 && SOCKETCOMMAND="socat - $SOCKET"
-    type nc >/dev/null 2>&1 && SOCKETCOMMAND="nc -U -N $SOCKET"
+    type nc >/dev/null 2>&1 && SOCKETCOMMAND="nc -U $SOCKET"
 
     test "$SOCKETCOMMAND" || {
         printf '%s\n' "Cannot find socat or nc on your \$PATH." >&2


### PR DESCRIPTION
When running on Arch Linux, the error below occurs:

```
nc: invalid option -- 'N'
Try `nc --help' for more information.
```

This is found when running with `OpenBSD Netcat v1.105_7-7`. According to <http://linux.die.net/man/1/nc> there is no `-N` flag.

This error can be removed with the attached change.