### PR TITLE
Check which version of netcat is being used

### DIFF
--- a/mpvc
+++ b/mpvc
@@ -761,7 +761,7 @@ validateDeps() {
     }
 
     type socat >/dev/null 2>&1 && SOCKETCOMMAND="socat - $SOCKET"
-    type nc >/dev/null 2>&1 && SOCKETCOMMAND="nc -U -N $SOCKET"
+    type nc >/dev/null 2>&1 && SOCKETCOMMAND="nc -U $SOCKET"
 
     test "$SOCKETCOMMAND" || {
         printf '%s\n' "Cannot find socat or nc on your \$PATH." >&2

--- a/mpvc
+++ b/mpvc
@@ -761,7 +761,7 @@ validateDeps() {
     }
 
     type socat >/dev/null 2>&1 && SOCKETCOMMAND="socat - $SOCKET"
-    type nc >/dev/null 2>&1 && SOCKETCOMMAND="nc -U $SOCKET"
+    type nc >/dev/null 2>&1 && (nc -h 2>&1 | grep -q "BSD") && SOCKETCOMMAND="nc -U $SOCKET"
 
     test "$SOCKETCOMMAND" || {
         printf '%s\n' "Cannot find socat or nc on your \$PATH." >&2


### PR DESCRIPTION
Unix sockets are implemented using OpenBSD's netcat, not GNU's netcat.
Therefore we need to check that we're using the correct version of
netcat.

Depends on #27 being merged.